### PR TITLE
[base_util_refcodes] fix no field exception if the model has no name …

### DIFF
--- a/base_util_refcodes/name_tools.py
+++ b/base_util_refcodes/name_tools.py
@@ -43,7 +43,7 @@ def extended_name_get(obj, cr, uid, ids, name_mask, flds_templ, context=None):
     # Ensure ids is a list, so that read() also returns a list
     if not isinstance(ids, list):
         ids = [ids]
-    flds_templ = list(set(flds_templ + ['name']))
+    flds_templ = list(set(flds_templ + [obj._rec_name]))
     res = []
     for rec in obj.read(cr, uid, ids, flds_templ, context=context):
         for key in flds_templ:
@@ -55,7 +55,7 @@ def extended_name_get(obj, cr, uid, ids, name_mask, flds_templ, context=None):
         try:
             n = name_mask % rec
         except:
-            n = rec['name']  # fallback to default name
+            n = rec[obj._rec_name]  # fallback to default name
         res.append((rec['id'], n))
     return res
 


### PR DESCRIPTION
While i have a model having no "name" field. extended_name_get in base_util_refcodes will have error.

that's becase odoo can have no name field and you can specify which field to be the missing "name" field.

if have check the odoo model.py, you can see the code below:
        if cls._rec_name:
            assert cls._rec_name in cls._fields, \
                "Invalid rec_name %s for model %s" % (cls._rec_name, cls._name)
        elif 'name' in cls._fields:
            cls._rec_name = 'name'
        elif 'x_name' in cls._fields:
            cls._rec_name = 'x_name'
